### PR TITLE
Fix token not being recognised (Convert to string)

### DIFF
--- a/main.py
+++ b/main.py
@@ -102,4 +102,4 @@ shared_yaml = shared.load_config()
 client = DAB(config_directory, shared_yaml["prefix"])
 
 client.load_extension("src.COMMANDS")
-client.run(shared_yaml["token"], bot=False)
+client.run(f'{shared_yaml["token"]}', bot=False)


### PR DESCRIPTION
The bot wouldn't start because the token was being used without being a string.